### PR TITLE
fix: remove redundant Spotless config provided by shared CI init-script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,5 @@
-import com.diffplug.gradle.spotless.SpotlessExtension
-
 plugins {
     id("maven-publish")
-    id("com.diffplug.spotless") version "8.6.0"
     `java-library`
     kotlin("jvm") version "2.3.21"
 }
@@ -59,42 +56,5 @@ publishing {
                 }
             }
         }
-    }
-}
-
-configure<SpotlessExtension> {
-    kotlin {
-        target(
-            fileTree(".") {
-                include("**/*.kt")
-                exclude("**/.gradle/**")
-            },
-        )
-        // see https://github.com/shyiko/ktlint#standard-rules
-        ktlint()
-    }
-    kotlinGradle {
-        target(
-            fileTree(".") {
-                include("**/*.gradle.kts")
-                exclude("**/.gradle/**")
-            },
-        )
-        trimTrailingWhitespace()
-        ktlint()
-    }
-}
-
-val taskDependencies =
-    mapOf(
-        "spotlessKotlinGradle" to listOf("spotlessKotlin"),
-        "spotlessKotlin" to listOf("compileKotlin"),
-        "compileTestKotlin" to listOf("spotlessKotlinGradle"),
-    )
-
-taskDependencies.forEach {
-    val task = it.key
-    it.value.forEach { dependsOn ->
-        tasks.findByName(task)!!.dependsOn(dependsOn)
     }
 }


### PR DESCRIPTION
## What

Remove the `com.diffplug.spotless` plugin, the `SpotlessExtension` configuration block, and the spotless-only `taskDependencies` wiring from `build.gradle.kts`.

## Why

The shared `yonatankarp/github-actions/.github/workflows/linters.yml@v2` workflow now applies and configures Spotless itself via an init-script (curl'd from `github-actions@v2`) for any project with the Kotlin JVM plugin. Because this repo *also* declared and configured Spotless, CI applied the plugin twice and failed at configuration time:

```
> Failed to apply plugin class 'com.diffplug.gradle.spotless.SpotlessPlugin'.
   > Could not create an instance of type com.diffplug.gradle.spotless.SpotlessExtensionImpl.
      > Cannot add task 'spotlessCheck' as a task with that name already exists.
```

This blocked the linter check on every PR, including the open Dependabot PRs (#184 Kotlin 2.4.0, #186 Spotless 8.6→8.7). The Spotless declaration here is now redundant with the centralized config.

## Verification

Reproduced the failure locally against the central init-script, then confirmed the fix:

- `./gradlew --init-script <central spotless.gradle.kts> spotlessCheck` → BUILD SUCCESSFUL (was failing before)
- `./gradlew clean build` and `clean test` → BUILD SUCCESSFUL, 6 tests, 0 failures

## Follow-ups

- #184 (Kotlin 2.4.0) only needs a rebase once this lands; its build already passes.
- #186 (Spotless 8.6→8.7) becomes obsolete once the plugin declaration is gone and Dependabot will close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)